### PR TITLE
updated README to point out correct password parameter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,26 +30,26 @@ directly or indirectly affected.
 
 ## Overview
  - The VmBackup.py script is run from a XenServer host and utilizes the native
-   XenServer `xe vm-export` command to backup either Linux or Windows VMs. 
- - The vm-export is actually run after a vm-snapshot has occurred 
+   XenServer `xe vm-export` command to backup either Linux or Windows VMs.
+ - The vm-export is actually run after a vm-snapshot has occurred
    and this allows for backup while the VM is up and running.
  - These backup command techniques were originally discovered from anonymous
    Internet sources, then modified and developed into this python code.
- - During the backup of specified VMs, this script collects additional VM 
+ - During the backup of specified VMs, this script collects additional VM
    metadata using the Citrix XenServer XenAPI. This additional information
    can be useful during VM restore situations.
  - Backups can be run from multiple XenServer hosts and from multiple pools and
    all be written to a common area, if desired. That way, local as well as pooled
    SRs can be handled.
- - In addition to any scheduled cron backups, the VmBackup.py script can be run manually 
+ - In addition to any scheduled cron backups, the VmBackup.py script can be run manually
    as desired. However, it is important to keep in mind that the backup process does use
    important DOM0 resources, so running a backup during heavy workloads should be avoided.
  - The SR where VDI is located requires sufficient free space to hold a complete
-   snapshot of a VM. The temporary snapshots created during the backup process are deleted 
+   snapshot of a VM. The temporary snapshots created during the backup process are deleted
    after the vm-export has completed.
  - Optionally, if pool_db_backup=1 then the pool state backup occurs via
-   the `xe pool-dump-database` command. 
- - Optionally, compression of the vm-export file can be performed in the background 
+   the `xe pool-dump-database` command.
+ - Optionally, compression of the vm-export file can be performed in the background
    after each VM backup is completed by an independent user supplied cron job.
  - Optionally, status email can be sent by configuring optional VmBackup.py variables.
 
@@ -58,7 +58,7 @@ directly or indirectly affected.
 Typical Usage w/ config file for multiple vm backups:
 
     ./VmBackup.py <password> <config-file-path> [compress=True|False] [allow_extra_keys=True|False]
-  
+
 Alternate Usage w/ vm name for single vm backup:
 
     ./VmBackup.py <password> <vm-name> [compress=True|False] [allow_extra_keys=True|False]
@@ -67,10 +67,14 @@ Crontab example:
 
     10 0 * * 6 /usr/bin/python /snapshots/NAUbackup/VmBackup.py password /snapshots/NAUbackup/example.cfg >> /snapshots/NAUbackup/logs/VmBackup.log 2>&1
 
+### Password ###
+Provide the password for the user `root`. Make sure to set it in single quotes, e.g.  `'yourPassword'`.
+
+
 ### Command Line Parameters
  - *compress=True*          -> will trigger the 'xe vm-export compress=true' option during backup.
  - *compress=False*         -> (default) no immediate backup compression.
- - *allow_extra_keys=True*  -> Other scripts may read the same config file with some extra params, 
+ - *allow_extra_keys=True*  -> Other scripts may read the same config file with some extra params,
                            if this is the case then ignore extra configuration params.
  - *allow_extra_keys=False* -> (default) If extra keys exist, then an error will occur.
 
@@ -92,7 +96,7 @@ Crontab example:
     appear similar to this:
 
     `/snapshots myxenserver1.mycompany.org(rw,sync,no_root_squash)`
-    
+
   - In addition, rpcbind, mountd, lockd, statd and possibly also rquotad access should be
     granted to the NFS server from all XenServer hosts (for example, via tcpwrapper settings
     on the NFS server).
@@ -102,7 +106,7 @@ Crontab example:
 
 ## Installation
  1. Copy VmBackup.py to a XenServer local execution path.
- 2. From www.citrix.com/downloads - download the XenServer Software Development Kit 
+ 2. From www.citrix.com/downloads - download the XenServer Software Development Kit
      then copy file XenAPI.py into the same directory where VmBackup.py exists.
  3. Setup a %BACKUP_DIR% path (typically NFS) for VM backup storage.
  4. Edit the example configuration file for the appropriate settings.
@@ -115,20 +119,20 @@ Crontab example:
      - then edit crontab for regular execution cycles.
 
 ## Feature Discussion
- - A typical VmBackup.py run with vm-export specified creates a unique 
+ - A typical VmBackup.py run with vm-export specified creates a unique
    VM backup directory %BACKUP_DIR%/vm-name/date-time/. This VM backup directory
    contains (a) the vm backup xva file and (b) additional VM metadata.
 
 ## Additional Features
  - If running script from cron, then consider redirect to output file as the
    backup script output can be verbose and quite useful for error situations.
- - For each VM that is backed up it creates a unique backup directory 
+ - For each VM that is backed up it creates a unique backup directory
    *%BACKUP_DIR%/vm-name/date-time/*.
  - Associated VM metadata is stored in text files inside the
    *%BACKUP_DIR%/vm-name/date-time/* location.
- - The oldest %BACKUP_DIR%/vm-name/date-time/ entries are deleted when the number of 
+ - The oldest %BACKUP_DIR%/vm-name/date-time/ entries are deleted when the number of
    backups for a vm exceeds `%MAX_BACKUPS%`.
- - Before each new VM backup begins then a check is made to ensure that the last 
+ - Before each new VM backup begins then a check is made to ensure that the last
    VM backup was successful. If it was not successful then the previous backup directory
    will be deleted so that `%MAX_BACKUPS%` will not delete older 'successful' backups.
  - If the script is run with a config file, then extra logging occurs in the
@@ -145,3 +149,16 @@ To restore VM from backup, use the `xe vm-import` command. Use `xe help vm-impor
 
 ### Pool Restore
 In the situation where the pool is corrupt and no hosts will start in the pool then it may be necessary to restore and rebuild the XenServer pool. This decision should be carefully reviewed with advice from Citrix Support. Consult the Citrix XenServer Administrator's Guide chapter 8 and review sections that discuss the 'xe pool-restore-database' command.
+
+
+##  Troubleshooting ###
+### XenAPI authentication failed
+Console output:
+```
+['SESSION_AUTHENTICATION_FAILED', 'root', 'Authentication failure']
+ERROR - XenAPI authentication error
+```
+Possible reasons:
+- The password you provided as CLI-parameter is wrong. Provide the password for the `root` user.
+- The password contains a special character, e.g. "@" and prevents correct parsing.
+Provide the password in single quotes, e.g. `./VmBackup 'rootPasswordForTheXenHost' ...`


### PR DESCRIPTION
I had trouble getting the script to run properly because I failed to use the password CLI-parameter correctly (it included a special character and I used double quotes instead of single quotes). That's why I'd like to point out the correct usage in the README so others don't have to try and figure out what's going on.
