### PR TITLE
Fix #45, #43, #36, #39, #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ These new features have been added:
 	vdi-export=my-vm-name
 
 	# vm-export using VM prefix wildcard - notice DEV.* has :max_backups overide
-	# and note the necessary ".*" syntax needed to replicaite the "*" wildcard
+	# and note the necessary ".*" syntax needed to replicate the "*" wildcard
 	# syntax used in V3.0 and now deprecated. More detailed examples will
 	# be discussed elsewhere
 	vm-export=PROD.*

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -1331,11 +1331,11 @@ if __name__ == '__main__':
         usage()
         sys.exit(1)
     password = sys.argv[1]
-    cfg_file = sys.argv[2]
+    arg_3 = sys.argv[2]
     # obscure password support
     if (os.path.exists(password)): 
         password = base64.b64decode(open(password, 'r').read())
-    if cfg_file.lower().startswith('create-password-file'):
+    if arg_3.lower().startswith('create-password-file'):
         array = sys.argv[2].strip().split('=')
         open(array[1], 'w').write(base64.b64encode(password))
         print 'password file saved to: %s' % array[1]
@@ -1370,29 +1370,32 @@ if __name__ == '__main__':
 
     all_vms = get_all_vms()
     # process config file
-    if (os.path.exists(cfg_file)):
+    if (os.path.exists(arg_3)):
         # config file exists
         config_specified = 1
-        if config_load(cfg_file):
+        if config_load(arg_3):
             cleanup_vmexport_vdiexport_dups()
         else:
             print 'ERROR in config_load, consider ignore_extra_keys=true'
             sys.exit(1)
     else:
-        # no config file exists - so cfg_file is actual vm_name/prefix
+        # no config file exists - so arg_3 is actual vm_name/prefix
         config_specified = 0
         cmd_option = 'vm-export' # default
-        cmd_vm_name = cfg_file   # in this case a vm name pattern
+        cmd_vm_name = arg_3   # in this case a vm name pattern
         if cmd_vm_name.count('=') == 1:
             (cmd_option,cmd_vm_name) = cmd_vm_name.strip().split('=')
         if cmd_option != 'vm-export' and cmd_option != 'vdi-export':
-            print 'ERROR invalid config/vm_name: %s' % cfg_file
+            print 'ERROR invalid config/vm_name: %s' % cmd_vm_name
             usage()
             sys.exit(1)
         save_to_config_export( cmd_option, cmd_vm_name)
 
     config_load_defaults()  # set defaults that are not already loaded
-    log('VmBackup config loaded from: %s' % cfg_file)
+    if config_specified == 1:
+      log('VmBackup config loaded from: %s' % arg_3)
+    else:
+      log('Running with default config)
     config_print()     # show fully loaded config
     
     if not is_config_valid():

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -18,7 +18,7 @@
 # Title: NAUbackup / VmBackup - a XenServer vm-export and vdi-export Backup Script
 # Package Contents: README.md, VmBackup.py (this file), example.cfg
 # Version History
-# - v3.1 2016/11/26 Added regexp include/exclude syntax for slecting VMs,
+# - v3.1 2016/11/26 Added regexp include/exclude syntax for selecting VMs,
 #        checking writability of backup directory, SMTP TLS email option,
 #        define DEFAULT_STATUS_LOG parameter
 # - v3.0 2016/01/20 Added vdi-export for VMs with too many/large disks for vm-export

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -934,7 +934,7 @@ def save_to_config_exclude( key, vm_name):
     global error_regex
     found_match = False
     # Fail fast if exclude param given but empty to prevent from excluding all VMs
-    if vm_name = "":
+    if vm_name == "":
         return
     if not isNormalVmName(vm_name) and not isRegExValid( vm_name):
         log("***ERROR - invalid regex: %s=%s" % (key, vm_name))
@@ -1395,7 +1395,7 @@ if __name__ == '__main__':
     if config_specified == 1:
       log('VmBackup config loaded from: %s' % arg_3)
     else:
-      log('Running with default config)
+      log('Running with default config')
     config_print()     # show fully loaded config
     
     if not is_config_valid():

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -977,6 +977,9 @@ def save_to_config_export( key, value):
     for vm in all_vms:
         if ((isNormalVmName(vm_name_part) and vm_name_part == vm) or
             (not isNormalVmName(vm_name_part) and re.match(vm_name_part, vm))):
+            # Check if vdi-export already has the vm mentioned and, if so, do not add this vm to vm-export
+            if key == "vm-export" and vm in config['vdi-export']:
+                continue
             if vm_backups_part == '':
                 new_value = vm
             else:

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -933,7 +933,7 @@ def save_to_config_exclude( key, vm_name):
     global warning_match
     global error_regex
     found_match = False
-    # Fail fast if exclude param given but empty to prevent from exluding all VMs
+    # Fail fast if exclude param given but empty to prevent from excluding all VMs
     if vm_name = "":
         return
     if not isNormalVmName(vm_name) and not isRegExValid( vm_name):

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -944,7 +944,7 @@ def save_to_config_exclude( key, vm_name):
         if ((isNormalVmName(vm_name) and vm_name == vm) or
             (not isNormalVmName(vm_name) and re.match(vm_name, vm))):
             found_match = True
-            config[key].insert(0, vm)
+            config[key].append(vm)
     if not found_match:
         log("***WARNING - vm not found: %s=%s" % (key, vm_name))
         warning_match = True
@@ -991,7 +991,7 @@ def save_to_config_export( key, value):
             if key == "vm-export" and vm in config['vdi-export']:
                 continue
             else:
-                config[key].insert(0, new_value)
+                config[key].append(new_value)
     if not found_match:
         log("***WARNING - vm not found: %s=%s" % (key, value))
         warning_match = True
@@ -1136,7 +1136,7 @@ def config_print():
 
     log('  exclude (cnt)= %s' % len(config['exclude']))
     str = ''
-    for vm_parm in config['exclude']:
+    for vm_parm in sorted(config['exclude']):
         str += '%s, ' % vm_parm
     if len(str) > 1:
         str = str[:-2]
@@ -1144,7 +1144,7 @@ def config_print():
 
     log('  vdi-export (cnt)= %s' % len(config['vdi-export']))
     str = ''
-    for vm_parm in config['vdi-export']:
+    for vm_parm in sorted(config['vdi-export']):
         str += '%s, ' % vm_parm
     if len(str) > 1:
         str = str[:-2]
@@ -1152,7 +1152,7 @@ def config_print():
 
     log('  vm-export (cnt)= %s' % len(config['vm-export']))
     str = ''
-    for vm_parm in config['vm-export']:
+    for vm_parm in sorted(config['vm-export']):
         str += '%s, ' % vm_parm
     if len(str) > 1:
         str = str[:-2]

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -1072,7 +1072,7 @@ def verify_vm_exist(vm_name):
         return True
 
 def get_all_vms():
-    cmd = "%s/xe vm-list is-control-domain=false params=name-label --minimal" % xe_path
+    cmd = "%s/xe vm-list is-control-domain=false is-a-snapshot=false params=name-label --minimal" % xe_path
     vms = run_get_lastline(cmd)
     return vms.split(',')
 
@@ -1106,14 +1106,6 @@ def cleanup_vmexport_vdiexport_dups():
             if tmp_vm_parm == tmp_vdi_parm:
                 log('***WARNING vdi-export dup - remove vm-export=%s' % vm_parm) #debug
                 config['vm-export'].remove(vm_parm)
-
-def remove_excludes():
-    for vm_export in config['vm-export']:
-        if get_vm_name(vm_export) in config['exclude']:
-            config['vm-export'].remove(vm_export)
-    for vdi_export in config['vdi-export']:
-        if get_vm_name(vdi_export) in config['exclude']:
-            config['vdi-export'].remove(vdi_export)
 
 def config_load_defaults():
     # init config param not already loaded then load with default values
@@ -1377,16 +1369,7 @@ if __name__ == '__main__':
         # config file exists
         config_specified = 1
         if config_load(cfg_file):
-            # mystery - why is both next section and remove_excludes() needed???
-            #for vm_export in config['vm-export']:
-            #    if get_vm_name(vm_export) in config['exclude']:
-            #        config['vm-export'].remove(vm_export)
-            #for vdi_export in config['vdi-export']:
-            #    if get_vm_name(vdi_export) in config['exclude']:
-            #        config['vdi-export'].remove(vdi_export)
-            #remove_excludes()
             cleanup_vmexport_vdiexport_dups()
-
         else:
             print 'ERROR in config_load, consider ignore_extra_keys=true'
             sys.exit(1)

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -944,7 +944,7 @@ def save_to_config_exclude( key, vm_name):
         if ((isNormalVmName(vm_name) and vm_name == vm) or
             (not isNormalVmName(vm_name) and re.match(vm_name, vm))):
             found_match = True
-            config[key].append(vm)
+            config[key].insert(0, vm)
     if not found_match:
         log("***WARNING - vm not found: %s=%s" % (key, vm_name))
         warning_match = True
@@ -985,7 +985,7 @@ def save_to_config_export( key, value):
             else:
                 new_value = "%s:%s" % (vm, vm_backups_part)
             found_match = True
-            config[key].append(new_value)
+            config[key].insert(0, new_value)
     if not found_match:
         log("***WARNING - vm not found: %s=%s" % (key, value))
         warning_match = True

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -977,15 +977,16 @@ def save_to_config_export( key, value):
     for vm in all_vms:
         if ((isNormalVmName(vm_name_part) and vm_name_part == vm) or
             (not isNormalVmName(vm_name_part) and re.match(vm_name_part, vm))):
-            # Check if vdi-export already has the vm mentioned and, if so, do not add this vm to vm-export
-            if key == "vm-export" and vm in config['vdi-export']:
-                continue
             if vm_backups_part == '':
                 new_value = vm
             else:
                 new_value = "%s:%s" % (vm, vm_backups_part)
             found_match = True
-            config[key].insert(0, new_value)
+            # Check if vdi-export already has the vm mentioned and, if so, do not add this vm to vm-export
+            if key == "vm-export" and vm in config['vdi-export']:
+                continue
+            else:
+                config[key].insert(0, new_value)
     if not found_match:
         log("***WARNING - vm not found: %s=%s" % (key, value))
         warning_match = True

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -959,12 +959,17 @@ def save_to_config_export( key, value):
     global warning_match
     global error_regex
     found_match = False
+
+    # Fail fast if all VMs excluded or if no VMs exist in the pool
+    if all_vms == []:
+        return
+
     # Fail fast if vdi-export given but empty to prevent from matching all VMs first-come-first-served style
-    # i.e. this could lead to vdi-export being empty but overriding all vm-export selections simply because
-    # it is listed first in the config
     # NOTE: This checks for the vdi-export key only so leaving vm-export empty will still default to all VMs
     if key == "vdi-export" and value == "":
         return
+
+    # Evaluate key/value pairs if we get this far
     values = value.split(':')
     vm_name_part = values[0]
     vm_backups_part = ''

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -39,7 +39,7 @@
 # Usage w/ config file for multiple vm backups, where you can specify either vm-export or vdi-export:
 #    ./VmBackup.py <password> <config-file-path>
 
-import sys, time, os, datetime, subprocess, re, shutil, XenAPI, smtplib, re, base64, socket
+import sys, time, os, datetime, subprocess, re, shutil, XenAPI, smtplib, base64, socket
 from email.MIMEText import MIMEText
 from subprocess import PIPE
 from subprocess import STDOUT

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -39,7 +39,7 @@
 # Usage w/ config file for multiple vm backups, where you can specify either vm-export or vdi-export:
 #    ./VmBackup.py <password> <config-file-path>
 
-import sys, time, os, datetime, subprocess, re, shutil, XenAPI, smtplib, re, base64
+import sys, time, os, datetime, subprocess, re, shutil, XenAPI, smtplib, re, base64, socket
 from email.MIMEText import MIMEText
 from subprocess import PIPE
 from subprocess import STDOUT
@@ -797,6 +797,9 @@ def df_snapshots(log_msg):
         log(line)
 
 def send_email(to, subject, body_fname):
+    
+    smtp_send_retries = 3
+    smtp_send_attempt = 0
 
     message = open('%s' % body_fname, 'r').read()
 
@@ -805,30 +808,43 @@ def send_email(to, subject, body_fname):
     msg['From'] = MAIL_FROM_ADDR
     msg['To'] = to
 
-    # note if using an ipaddress in MAIL_SMTP_SERVER, 
-    # then may require smtplib.SMTP(MAIL_SMTP_SERVER, local_hostname="localhost")
+    while smtp_send_attempt < smtp_send_retries:
+        smtp_send_attempt += 1
+        if smtp_send_attempt > smtp_send_retries:
+            print("Send email count limit exceeded")
+            sys.exit(1)
+        try:
+            # note if using an ipaddress in MAIL_SMTP_SERVER, 
+            # then may require smtplib.SMTP(MAIL_SMTP_SERVER, local_hostname="localhost")
 
-## Optional use of SMTP user authentication via TLS
-##
-## If so, comment out the next line of code and uncomment/configure
-## the next block of code. Note that different SMTP servers will require
-## different username options, such as the plain username, the
-## domain\username, etc. The "From" email address entry must be a valid
-## email address that can be authenticated  and should be configured
-## in the MAIL_FROM_ADDR variable along with MAIL_SMTP_SERVER early in
-## the script. Note that some SMTP servers might use port 465 instead of 587.
-    s = smtplib.SMTP(MAIL_SMTP_SERVER)
-#### start block
-    #username = 'MyLogin'
-    #password = 'MyPassword'
-    #s = smtplib.SMTP(MAIL_SMTP_SERVER, 587)
-    #s.ehlo()
-    #s.starttls()
-    #s.login(username, password)
-#### end block
-    s.sendmail(MAIL_FROM_ADDR, to.split(','), msg.as_string())
-    s.quit()
-
+            ## Optional use of SMTP user authentication via TLS
+            ##
+            ## If so, comment out the next line of code and uncomment/configure
+            ## the next block of code. Note that different SMTP servers will require
+            ## different username options, such as the plain username, the
+            ## domain\username, etc. The "From" email address entry must be a valid
+            ## email address that can be authenticated  and should be configured
+            ## in the MAIL_FROM_ADDR variable along with MAIL_SMTP_SERVER early in
+            ## the script. Note that some SMTP servers might use port 465 instead of 587.
+            s = smtplib.SMTP(MAIL_SMTP_SERVER)
+            #### start block
+            #username = 'MyLogin'
+            #password = 'MyPassword'
+            #s = smtplib.SMTP(MAIL_SMTP_SERVER, 587)
+            #s.ehlo()
+            #s.starttls()
+            #s.login(username, password)
+            #### end block
+            s.sendmail(MAIL_FROM_ADDR, to.split(','), msg.as_string())
+            s.quit()
+            break
+        except socket.error as e:
+            print("Exception: socket.error - {}".format(e))
+            time.sleep(5)
+        except smtplib.SMTPException as e:
+            print("Exception: SMTPException - {}".format(e.message))
+            time.sleep(5)
+            
 def is_xe_master():
     # test to see if we are running on xe master
 
@@ -910,20 +926,6 @@ def config_load(path):
 
     return return_value
 
-#def save_to_config_exclude( key, vm_name):
-#    # save key/value in config[]
-#    global warning_match
-#    found_match = False
-#    for vm in all_vms:
-#        if vm_name == vm:
-#            all_vms.remove(vm)
-#            found_match = True
-#            config[key].append(vm_name)
-#            return
-#    if not found_match:
-#        log("***WARNING - vm not found: %s=%s" % (key, vm_name))
-#        warning_match = True
-
 def save_to_config_exclude( key, vm_name):
     # save key/value in config[]
     # expected-key: exclude
@@ -938,12 +940,14 @@ def save_to_config_exclude( key, vm_name):
     for vm in all_vms:
         if ((isNormalVmName(vm_name) and vm_name == vm) or
             (not isNormalVmName(vm_name) and re.match(vm_name, vm))):
-            all_vms.remove(vm)
             found_match = True
             config[key].append(vm)
     if not found_match:
         log("***WARNING - vm not found: %s=%s" % (key, vm_name))
         warning_match = True
+    else:
+        for vm in config[key]:
+            all_vms.remove(vm)
 
 def save_to_config_export( key, value):
     # save key/value in config[]
@@ -964,7 +968,6 @@ def save_to_config_export( key, value):
     for vm in all_vms:
         if ((isNormalVmName(vm_name_part) and vm_name_part == vm) or
             (not isNormalVmName(vm_name_part) and re.match(vm_name_part, vm))):
-            all_vms.remove(vm)
             if vm_backups_part == '':
                 new_value = vm
             else:


### PR DESCRIPTION
Incorporates changes from #39 and #46 but actually implements a complete fix for the exclude when using regexp.

The all_vms list was being updated inside the loop that is iterating over that same list. This causes the loop to break which is why even a ```exclude=.*``` will not exclude more than one match. The fix was to move the updating of the all_vms array after the loop and only when ```found_match``` is ```true```.

This code also removes the ```all_vms.remove(vm)``` line completely from the ```save_to_config_export``` function which shouldn't be removing anything as it is for **adding** to the array, not removing.