### PR TITLE
Added status_log placeholder

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -31,6 +31,8 @@ max_backups=3
 
 #Backup Directory path (script default /snapshots/BACKUPS)
 backup_dir=/path/to/backupspace
+# Status log written during operations
+status_log=/path/to/status.log
 
 # applicable if vdi-export is used
 # vdi_export_format either raw or vhd (script default to raw)


### PR DESCRIPTION
First time I ran it, it tried to create a status.log in `/snapshots/NAUbackup/status.log` which obviously failed. I think it's worth it to put a placeholder in the example config file. Not likely to succeed unless someone set this.

Thanks for creating this script!