### PR TITLE
Add possibility to read password from stdin

### DIFF
--- a/VmBackup.py
+++ b/VmBackup.py
@@ -65,7 +65,7 @@
 # Usage w/ config file for multiple vm backups, where you can specify either vm-export or vdi-export:
 #    ./VmBackup.py <password> <config-file-path>
 
-import sys, time, os, datetime, subprocess, re, shutil, XenAPI, smtplib, re, base64, socket
+import sys, time, os, datetime, subprocess, re, shutil, XenAPI, smtplib, re, base64, socket, signal
 from email.MIMEText import MIMEText
 from subprocess import PIPE
 from subprocess import STDOUT
@@ -1370,32 +1370,41 @@ def usage_examples():
     print
 
 def read_char_non_block(file_object,Block=True):
-  if Block or select.select([file_object], [], [], 0) == ([file_object], [], []):
-    char = file_object.read(1)
-    return char
-  raise error('Could not read password from stream')
-
-import time
+  timeout=1
+  signal.signal(signal.SIGALRM, input)
+  signal.alarm(timeout)
+  try:
+    if Block or select.select([file_object], [], [], 0) == ([file_object], [], []):
+      return file_object.read(1)
+  except:
+      return
 
 def read_password_from_stdin():
   password=""
   while True:
-    char = read_char_non_block(sys.stdin,True)
+    char = read_char_non_block(sys.stdin)
     if char:
        password += char
     else:
-       return password.rstrip()
+	if len(password) > 0:
+	  return password.rstrip()
+	else:
+          return
 
 def get_password(password_arg):
 
     # read password from stdin if password_arg is a dash("-")
     if password_arg == "-":
-       return read_password_from_stdin()
+	password = read_password_from_stdin()
+        if password:
+          return password
+        else:
+          raise "FATAL: Could not get password from stdin"
 
     # return base64-decoded file content if password_arg is an existing file
     if (os.path.exists(password)): 
-        password = base64.b64decode(open(password, 'r').read())
-       return password
+      password = base64.b64decode(open(password, 'r').read())
+      return password
 
     # else take the given password_arg as clear text password
     return pasword_arg


### PR DESCRIPTION
I'd like to have the possibility to have the password read from stdin to reduce the danger for the password to be easily captured when having root access to a XenServer.

At the moment the password is visible in the process list when directly supplied at the command line or nearly cleartext in the specified file base64-encoded. 

That added change adds a third possibility: Specify "-" as the password in which case the password is read from stdin like this:

`VmBackup.py - <<<'secret_password'`

In this way the password is not shown in the process list and it does not have to be present on all XenServers. It can be kept on a secure remote machine, which initiates the start of the script.